### PR TITLE
Adjust picklist start number

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ Wrote non_cherrypicked ECHO pick list to test_output/non_cherrypicked/MAA000154_
 ### Example: Aggergate
 
 
-```
+
 ```
 dobby  aggregate  --desired-concentration 0.3 ~/Google\ Drive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3\ Month/cherrypicked/*.csv --output-folder ~/Google\ Drive/MACA/cDNA\ Pick\ Lists/3_month/
+```
 
 Advanced usage: sort files by date, then aggregate:
 


### PR DESCRIPTION
This is semi working .. but something is weird for the last number of picklists [example here](https://gist.github.com/olgabot/638fb1b6323454f09844059ecd206647).

Here's an excerpt where I run this with the exact same cherrypick lists. So the second time I run it, it shouldn't write anything:

```
(dobby) ➜  dobby git:(adjust_picklist_start_number) ✗ ls -Str ~/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/*.csv |  xargs sobby aggregate --output-folder test_aggregate 
zsh: correct 'sobby' to 'dobby' [nyae]? y
Reading exising pick lists in test_aggregate ...
	Done. 15 picklists found.
Wrote 7 files (/Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/B003285_echo.csv, /Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA001854_echo.csv, /Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/B001688_echo.csv, /Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA001897_echo.csv, /Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA001856_echo.csv, /Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA000545_echo.csv, /Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA001896_echo.csv) to test_aggregate/echo_picklist_00015.csv
... lots more output ...
Wrote 2 files (/Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA001539_echo.csv, /Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA001884_echo.csv) to test_aggregate/echo_picklist_00063.csv
145 samples from (/Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA001884_echo.csv) didn't make it into a pick list :(
(dobby) ➜  dobby git:(adjust_picklist_start_number) ✗ ls -Str ~/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/*.csv |  xargs dobby aggregate --output-folder test_aggregate 
Reading exising pick lists in test_aggregate ...
	Done. 63 picklists found.
Already saw B003285 in echo_picklist_00015.csv, skipping ...
Already saw MAA001854 in echo_picklist_00015.csv, skipping ...
... lots more output ...
Already saw MAA000607 in echo_picklist_00061.csv,echo_picklist_00062.csv, skipping ...
	Already wrote 347 samples to echo_picklist_00062.csv,echo_picklist_00063.csv, 1 samples remaining for next picklist
	Already wrote 205 samples to echo_picklist_00063.csv, 146 samples remaining for next picklist
Wrote 3 files (MAA001887_echo.csv, MAA001539_echo.csv, MAA001884_echo.csv) to test_aggregate/echo_picklist_00063.csv
38 samples from (/Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA001884_echo.csv) didn't make it into a pick list :(
```

Notice  the last line of the first run:
```
145 samples from (/Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA001884_echo.csv) didn't make it into a pick list :(
```

Which means that no pick list should be written in the second, run, but it writes to picklist 63!! And somehow has more samples left over?!?!?

```
Wrote 3 files (MAA001887_echo.csv, MAA001539_echo.csv, MAA001884_echo.csv) to test_aggregate/echo_picklist_00063.csv
38 samples from (/Users/olgabot/googledrive/MACA/384W_QC/plate_reader/raw_plate_reader_output/3Month/cherrypicked/MAA001884_echo.csv) didn't make it into a pick list :(
```

Very confusing...